### PR TITLE
avoid truncation of "unsigned short" max to short

### DIFF
--- a/src/osg/ImageUtils.cpp
+++ b/src/osg/ImageUtils.cpp
@@ -74,7 +74,7 @@ osg::ref_ptr<osg::Image> formatImage(const osg::Image* image, GLenum targetPixel
             break;
         case(GL_UNSIGNED_SHORT) :
             numBytesPerComponent = 2;
-            *reinterpret_cast<short*>(component_default) = 65535;
+            *reinterpret_cast<unsigned short*>(component_default) = 65535;
             break;
         case(GL_INT) :
             numBytesPerComponent = 4;


### PR DESCRIPTION
Hi Robert,
while compiling vsgXchange with Microsoft Visual Studio Community 2019 Version 16.7.2
the compiler generated a warning:
vsgXchange\src\osg\ImageUtils.cpp(77,60): warning C4309: '=': truncation of constant value

I think this is an actual bug (value truncated to 15 bits) but I did not check to see if the result is different after compilation.
Regards, Laurens.