### PR TITLE
fix MSVC warning C4099: 'osg2vsg::PipelineCache': type name first seen using 'class' now seen using 'struct'

### DIFF
--- a/src/osg/SceneBuilder.h
+++ b/src/osg/SceneBuilder.h
@@ -18,8 +18,9 @@
 
 namespace osg2vsg
 {
-    struct PipelineCache : public vsg::Inherit<vsg::Object, PipelineCache>
+    class PipelineCache : public vsg::Inherit<vsg::Object, PipelineCache>
     {
+        public:
         vsg::ref_ptr<vsgXchange::ShaderCompiler> shaderCompiler = vsgXchange::ShaderCompiler::create();
 
         using Key = std::tuple<uint32_t, uint32_t, std::string, std::string>;


### PR DESCRIPTION
Hi Robert,
trying to fix a compiler warning I do not fully understand.
I think the code has exactly the same result, and don't see why "struct BuildOptions" just below this gets no warning.
Feel free to reject this PR to keep the warning and wait to someone can explain what the actual problem is.

Regards, Laurens.