### PR TITLE
fix MSVC warning C4099: 'osg2vsg::PipelineCache': type name first seen using 'class' now seen using 'struct'

### DIFF
--- a/src/osg/ReaderWriter_osg.h
+++ b/src/osg/ReaderWriter_osg.h
@@ -7,7 +7,7 @@
 
 namespace osg2vsg
 {
-    class PipelineCache;
+    struct PipelineCache;
 }
 
 namespace vsgXchange


### PR DESCRIPTION
found the declaration as struct in  src/osg/ReaderWriter_osg.h
Regards, Laurens.