### PR TITLE
KTX texture read support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.7)
 project(VSGXCHANGE
     VERSION 0.0.0
     DESCRIPTION "VulkanSceneGraph 3rd party data integration library"
-    LANGUAGES CXX
+    LANGUAGES CXX C
 )
 set(VSGXCHANGE_SOVERSION 0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,17 @@ if(assimp_FOUND)
     set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
 endif()
 
+find_package(ktx)
+if(ktx_FOUND)
+    set(SOURCES ${SOURCES}
+        ktx/ReaderWriter_ktx.cpp
+    )
+    set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${ktx_INCLUDE_DIRS})
+    set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} KTX::ktx)
+    set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_KTX)
+    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(ktx)")
+endif()
+
 # add optional OpenSceneGraph components
 include(osg/build_vars.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ if(assimp_FOUND)
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${assimp_INCLUDE_DIRS})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} assimp::assimp)
     set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_ASSIMP)
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
+    set(FIND_DEPENDENCY_ASSIMP "find_dependency(assimp)")
 endif()
 
 find_package(ktx)
@@ -54,7 +54,7 @@ if(ktx_FOUND)
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${ktx_INCLUDE_DIRS})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} KTX::ktx)
     set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_KTX)
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(ktx)")
+    set(FIND_DEPENDENCY_KTX "find_dependency(ktx)")
 endif()
 
 # add optional OpenSceneGraph components

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ if(assimp_FOUND)
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${assimp_INCLUDE_DIRS})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} assimp::assimp)
     set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_ASSIMP)
-    set(FIND_DEPENDENCY_ASSIMP "find_dependency(assimp)")
+    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
 endif()
 
 find_package(ktx)
@@ -54,7 +54,7 @@ if(ktx_FOUND)
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${ktx_INCLUDE_DIRS})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} KTX::ktx)
     set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_KTX)
-    set(FIND_DEPENDENCY_KTX "find_dependency(ktx)")
+    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(ktx)")
 endif()
 
 # add optional OpenSceneGraph components
@@ -112,6 +112,7 @@ write_basic_package_version_file("${CMAKE_BINARY_DIR}/src/vsgXchangeConfigVersio
     COMPATIBILITY SameMajorVersion
 )
 
+string(REPLACE ";" "\n" FIND_DEPENDENCY_OUT "${FIND_DEPENDENCY}")
 configure_file("${CMAKE_SOURCE_DIR}/src/vsgXchangeConfig.cmake.in" "${CMAKE_BINARY_DIR}/src/vsgXchangeConfig.cmake" @ONLY)
 
 install(FILES "${CMAKE_BINARY_DIR}/src/vsgXchangeConfig.cmake" "${CMAKE_BINARY_DIR}/src/vsgXchangeConfigVersion.cmake"

--- a/src/dds/ReaderWriter_dds.cpp
+++ b/src/dds/ReaderWriter_dds.cpp
@@ -95,9 +95,9 @@ namespace
         case VK_FORMAT_BC4_SNORM_BLOCK:
         case VK_FORMAT_BC4_UNORM_BLOCK:
             if (isCubemap && numArrays == 6)
-                vsg_data = vsg::block64ArrayCube::create(width / 4, height / 4, reinterpret_cast<vsg::block64*>(raw), layout);
+                vsg_data = vsg::block64ArrayCube::create(width / layout.blockWidth, height / layout.blockHeight, reinterpret_cast<vsg::block64*>(raw), layout);
             else
-                vsg_data = vsg::block64Array2D::create(width / 4, height / 4, reinterpret_cast<vsg::block64*>(raw), layout);
+                vsg_data = vsg::block64Array2D::create(width / layout.blockWidth, height / layout.blockHeight, reinterpret_cast<vsg::block64*>(raw), layout);
             break;
             break;
         case VK_FORMAT_BC2_UNORM_BLOCK:
@@ -109,9 +109,9 @@ namespace
         case VK_FORMAT_BC7_UNORM_BLOCK:
         case VK_FORMAT_BC7_SRGB_BLOCK:
             if (isCubemap && numArrays == 6)
-                vsg_data = vsg::block128ArrayCube::create(width / 4, height / 4, reinterpret_cast<vsg::block128*>(raw), layout);
+                vsg_data = vsg::block128ArrayCube::create(width / layout.blockWidth, height / layout.blockHeight, reinterpret_cast<vsg::block128*>(raw), layout);
             else
-                vsg_data = vsg::block128Array2D::create(width / 4, height / 4, reinterpret_cast<vsg::block128*>(raw), layout);
+                vsg_data = vsg::block128Array2D::create(width / layout.blockWidth, height / layout.blockHeight, reinterpret_cast<vsg::block128*>(raw), layout);
             break;
         }
 

--- a/src/ktx/ReaderWriter_ktx.cpp
+++ b/src/ktx/ReaderWriter_ktx.cpp
@@ -1,0 +1,202 @@
+#include "ReaderWriter_ktx.h"
+
+#include <vsg/state/DescriptorImage.h>
+
+#include <ktx.h>
+#include <ktxvulkan.h>
+
+#include <algorithm>
+
+namespace
+{
+        const std::unordered_set<VkFormat> kFormatSet{
+            VK_FORMAT_R8G8B8A8_UNORM,
+            VK_FORMAT_R8G8B8A8_SNORM,
+            VK_FORMAT_R8G8B8A8_SRGB,
+            VK_FORMAT_BC7_UNORM_BLOCK,
+            VK_FORMAT_BC7_SRGB_BLOCK,
+            VK_FORMAT_BC5_UNORM_BLOCK,
+            VK_FORMAT_BC5_SNORM_BLOCK,
+            VK_FORMAT_BC4_UNORM_BLOCK,
+            VK_FORMAT_BC4_SNORM_BLOCK,
+            VK_FORMAT_BC3_UNORM_BLOCK,
+            VK_FORMAT_BC3_SRGB_BLOCK,
+            VK_FORMAT_BC2_UNORM_BLOCK,
+            VK_FORMAT_BC2_SRGB_BLOCK,
+            VK_FORMAT_BC1_RGB_UNORM_BLOCK,
+            VK_FORMAT_BC1_RGB_SRGB_BLOCK,
+            VK_FORMAT_BC1_RGBA_UNORM_BLOCK,
+            VK_FORMAT_BC1_RGBA_SRGB_BLOCK
+        };
+
+    vsg::ref_ptr<vsg::Data> readKtx(ktxTexture* texture)
+    {
+        vsg::ref_ptr<vsg::Data> data;
+        const auto width = texture->baseWidth;
+        const auto height = texture->baseHeight;
+        const auto depth = texture->baseDepth;
+        const auto numMipMaps = texture->numLevels;
+        const auto numArrays = texture->numFaces;
+        const auto textureData = ktxTexture_GetData(texture);
+        const auto textureSize = ktxTexture_GetDataSize(texture);
+        const auto format = ktxTexture_GetVkFormat(texture);
+        const auto valueSize = ktxTexture_GetElementSize(texture);
+
+        if (kFormatSet.count(format) > 0)
+        {
+            const uint32_t blockSize = texture->isCompressed ? 4 : 1;
+            size_t offset = 0;
+            auto mipWidth = (width) / blockSize;
+            auto mipHeight = (height) / blockSize;
+            auto mipDepth = depth;
+
+            using image_t = std::vector<uint8_t>;
+            std::vector<image_t> images(numMipMaps * numArrays);
+
+
+            for (uint32_t i = 0; i < numMipMaps; ++i)
+            {
+                const auto faceSize = std::max(mipWidth * mipHeight * mipDepth * valueSize, valueSize);
+
+                for (uint32_t j = 0; j < numArrays; ++j)
+                {
+                    auto& face = images[numArrays * i + j];
+
+                    if (ktx_size_t ktxOffset = 0; ktxTexture_GetImageOffset(texture, i, 0, j, &ktxOffset) == KTX_SUCCESS)
+                    {
+                        face.reserve(faceSize);
+                        face.assign((uint8_t*)textureData + ktxOffset, (uint8_t*)textureData + ktxOffset + faceSize);
+                    }
+
+                    offset += faceSize;
+                }
+
+                if (mipWidth > 1) mipWidth /= 2;
+                if (mipHeight > 1) mipHeight /= 2;
+                if (mipDepth > 1) mipDepth /= 2;
+            }
+
+            auto raw = new uint8_t[offset];
+            offset = 0;
+
+            for (auto& image : images)
+            {
+                std::memcpy(raw + offset, image.data(), image.size());
+                offset += image.size();
+            }
+
+            vsg::Data::Layout layout;
+            layout.format = format;
+            layout.maxNumMipmaps = numMipMaps;
+
+            switch (format)
+            {
+            case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+            case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+            case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+            case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+            case VK_FORMAT_BC4_SNORM_BLOCK:
+            case VK_FORMAT_BC4_UNORM_BLOCK:
+                layout.blockWidth = blockSize;
+                layout.blockHeight = blockSize;
+
+                if (height > 1 && depth == 1)
+                {
+                    // 2d texture
+                    if (texture->isCubemap)
+                    {
+                        data = vsg::block64ArrayCube::create(width / blockSize, height / blockSize, reinterpret_cast<vsg::block64*>(raw), layout);
+                    }
+                    else
+                    {
+                        data = vsg::block64Array2D::create(width / blockSize, height / blockSize, reinterpret_cast<vsg::block64*>(raw), layout);
+                    }
+                }
+                break;
+
+            case VK_FORMAT_BC2_UNORM_BLOCK:
+            case VK_FORMAT_BC2_SRGB_BLOCK:
+            case VK_FORMAT_BC3_UNORM_BLOCK:
+            case VK_FORMAT_BC3_SRGB_BLOCK:
+            case VK_FORMAT_BC5_UNORM_BLOCK:
+            case VK_FORMAT_BC5_SNORM_BLOCK:
+            case VK_FORMAT_BC7_UNORM_BLOCK:
+            case VK_FORMAT_BC7_SRGB_BLOCK:
+                layout.blockWidth = blockSize;
+                layout.blockHeight = blockSize;
+
+                if (height > 1 && depth == 1)
+                {
+                    // 2d texture
+                    if (texture->isCubemap)
+                    {
+                        data = vsg::block128ArrayCube::create(width / blockSize, height / blockSize, reinterpret_cast<vsg::block128*>(raw), layout);
+                    }
+                    else
+                    {
+                        data = vsg::block128Array2D::create(width / blockSize, height / blockSize, reinterpret_cast<vsg::block128*>(raw), layout);
+                    }
+                }
+                break;
+
+            default:
+                if (height > 1 && depth == 1)
+                {
+                    // 2d texture
+                    if (texture->isCubemap)
+                        data = vsg::ubvec4ArrayCube::create(width, height, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                    else
+                        data = vsg::ubvec4Array2D::create(width, height, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                }
+                break;
+            }
+        }
+
+        ktxTexture_Destroy(texture);
+
+        return data;
+    }
+
+} // namespace
+
+using namespace vsgXchange;
+
+ReaderWriter_ktx::ReaderWriter_ktx() :
+    _supportedExtensions{"ktx", "ktx2"}
+{
+}
+
+vsg::ref_ptr<vsg::Object> ReaderWriter_ktx::read(const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> options) const
+{
+    if (const auto ext = vsg::lowerCaseFileExtension(filename); _supportedExtensions.count(ext) == 0)
+        return {};
+
+    if (!vsg::fileExists(filename))
+        return {};
+
+    if (ktxTexture * texture{nullptr}; ktxTexture_CreateFromNamedFile(filename.c_str(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &texture) == KTX_SUCCESS)
+        return readKtx(texture);
+
+    return {};
+}
+
+vsg::ref_ptr<vsg::Object> ReaderWriter_ktx::read(std::istream& fin, vsg::ref_ptr<const vsg::Options> options) const
+{
+    if (_supportedExtensions.count(options->extensionHint) == 0)
+        return {};
+
+    std::string buffer(1 << 16, 0); // 64kB
+    std::string input;
+
+    while (!fin.eof())
+    {
+        fin.read(&buffer[0], buffer.size());
+        const auto bytes_readed = fin.gcount();
+        input.append(&buffer[0], bytes_readed);
+    }
+
+    if (ktxTexture * texture{nullptr}; ktxTexture_CreateFromMemory((const ktx_uint8_t*)input.data(), input.size(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &texture) == KTX_SUCCESS)
+        return readKtx(texture);
+
+    return {};
+}

--- a/src/ktx/ReaderWriter_ktx.h
+++ b/src/ktx/ReaderWriter_ktx.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vsg/io/ReaderWriter.h>
+#include <vsgXchange/Export.h>
+#include <unordered_set>
+
+namespace vsgXchange
+{
+
+    class VSGXCHANGE_DECLSPEC ReaderWriter_ktx : public vsg::Inherit<vsg::ReaderWriter, ReaderWriter_ktx>
+    {
+    public:
+        ReaderWriter_ktx();
+
+        vsg::ref_ptr<vsg::Object> read(const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> options = {}) const override;
+        vsg::ref_ptr<vsg::Object> read(std::istream& fin, vsg::ref_ptr<const vsg::Options> options = {}) const override;
+
+    private:
+        std::unordered_set<std::string> _supportedExtensions;
+    };
+
+} // namespace vsgXchange

--- a/src/vsgXchange/ReaderWriter_all.cpp
+++ b/src/vsgXchange/ReaderWriter_all.cpp
@@ -20,6 +20,10 @@
 #    include "../assimp/ReaderWriter_assimp.h"
 #endif
 
+#ifdef USE_KTX
+#    include "../ktx/ReaderWriter_ktx.h"
+#endif
+
 using namespace vsgXchange;
 
 ReaderWriter_all::ReaderWriter_all()
@@ -35,6 +39,9 @@ ReaderWriter_all::ReaderWriter_all()
 #endif
 #ifdef USE_ASSIMP
     add(vsgXchange::ReaderWriter_assimp::create());
+#endif
+#ifdef USE_KTX
+    add(vsgXchange::ReaderWriter_ktx::create());
 #endif
 #ifdef USE_OPENSCENEGRAPH
     add(vsgXchange::ReaderWriter_osg::create());

--- a/src/vsgXchangeConfig.cmake.in
+++ b/src/vsgXchangeConfig.cmake.in
@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Vulkan)
 find_dependency(vsg)
-@FIND_DEPENDENCY@
+@FIND_DEPENDENCY_ASSIMP@
+@FIND_DEPENDENCY_KTX@
 
 include("${CMAKE_CURRENT_LIST_DIR}/vsgXchangeTargets.cmake")

--- a/src/vsgXchangeConfig.cmake.in
+++ b/src/vsgXchangeConfig.cmake.in
@@ -2,7 +2,6 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Vulkan)
 find_dependency(vsg)
-@FIND_DEPENDENCY_ASSIMP@
-@FIND_DEPENDENCY_KTX@
+@FIND_DEPENDENCY_OUT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/vsgXchangeTargets.cmake")


### PR DESCRIPTION
This pull request will add ktx read support. You will need the ktx library from the [khronos group](https://github.com/KhronosGroup/KTX-Software). Only version 4 and above is supported, as version 3 is not using cmake. The 4.0.0-beta6 release is working fine.

The ktx reader supports version 1 and 2 of the ktx texture format.

-André
