### PR TITLE
In shared build mode, do not add dependencies to the generated cmake support files to development packages used only locally

### DIFF
--- a/src/assimp/build_vars.cmake
+++ b/src/assimp/build_vars.cmake
@@ -11,7 +11,9 @@ if (${vsgXchange_assimp})
     )
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${assimp_INCLUDE_DIRS})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} assimp::assimp)
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
+    if(NOT BUILD_SHARED_LIBS)
+        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
+    endif()
 else()
     set(SOURCES ${SOURCES}
         assimp/assimp_fallback.cpp

--- a/src/curl/build_vars.cmake
+++ b/src/curl/build_vars.cmake
@@ -10,7 +10,9 @@ if(${vsgXchange_CURL})
         curl/curl.cpp
     )
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${CURL_LIBRARIES})
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(CURL)")
+    if(NOT BUILD_SHARED_LIBS)
+        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(CURL)")
+    endif()
 else()
     set(SOURCES ${SOURCES}
         curl/curl_fallback.cpp

--- a/src/gdal/build_vars.cmake
+++ b/src/gdal/build_vars.cmake
@@ -10,7 +10,9 @@ if(${vsgXchange_GDAL})
         gdal/GDAL.cpp
     )
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} vsgGIS::vsgGIS)
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(vsgGIS)")
+    if(NOT BUILD_SHARED_LIBS)
+        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(vsgGIS)")
+    endif()
 else()
     set(SOURCES ${SOURCES}
         gdal/GDAL_fallback.cpp

--- a/src/osg/build_vars.cmake
+++ b/src/osg/build_vars.cmake
@@ -23,7 +23,9 @@ if (${vsgXchange_OSG})
     )
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${OSG_INCLUDE_DIR})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${OPENTHREADS_LIBRARIES} ${OSG_LIBRARIES} ${OSGUTIL_LIBRARIES} ${OSGDB_LIBRARIES} ${OSGTERRAIN_LIBRARIES})
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(OpenThreads)" "find_dependency(osg)" "find_dependency(osgDB)" "find_dependency(osgTerrain)" "find_dependency(osgUtil)")
+    if(NOT BUILD_SHARED_LIBS)
+        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(OpenThreads)" "find_dependency(osg)" "find_dependency(osgDB)" "find_dependency(osgTerrain)" "find_dependency(osgUtil)")
+    endif()
 else()
     set(SOURCES ${SOURCES}
         osg/OSG_fallback.cpp


### PR DESCRIPTION
Fixes vsg-dev/vsgXchange#54