### PR TITLE
Remove unnecessary dependency on the Vulkan cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ if (VULKAN_SDK)
     set(ENV{VULKAN_SDK} ${VULKAN_SDK})
 endif()
 
-find_package(Vulkan REQUIRED)
 find_package(vsg 0.1.8 REQUIRED)
 
 vsg_setup_build_vars()

--- a/src/vsgXchangeConfig.cmake.in
+++ b/src/vsgXchangeConfig.cmake.in
@@ -1,6 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(Vulkan)
 find_dependency(vsg)
 @FIND_DEPENDENCY_OUT@
 


### PR DESCRIPTION
The vsg cmake package already provides this dependency.

See vsg-dev/VulkanSceneGraph#312