### PR TITLE
cmake: limit finding assimp to version < 5.1

### DIFF
--- a/src/assimp/build_vars.cmake
+++ b/src/assimp/build_vars.cmake
@@ -1,5 +1,5 @@
 # add assimp if vailable
-find_package(assimp 5.0.0 QUIET)
+find_package(assimp 5.0 EXACT)
 
 if(assimp_FOUND)
     OPTION(vsgXchange_assimp "Optional Assimp support provided" ON)


### PR DESCRIPTION
Workaround until https://github.com/vsg-dev/vsgXchange/issues/65 has been fixed.