### PR TITLE
Mingw32 compile fixes

### DIFF
--- a/src/assimp/assimp_fallback.cpp
+++ b/src/assimp/assimp_fallback.cpp
@@ -44,3 +44,7 @@ bool assimp::getFeatures(Features&) const
 {
     return false;
 }
+bool assimp::readOptions(vsg::Options&, vsg::CommandLine&) const
+{
+    return false;
+}

--- a/src/ktx/libktx/filestream.c
+++ b/src/ktx/libktx/filestream.c
@@ -50,6 +50,8 @@
   #define S_IFIFO _S_IFIFO
   #define S_IFSOCK 0xC000
   typedef unsigned short mode_t;
+#elif defined(__MINGW32__)
+  #define S_IFSOCK 0xC000
 #endif
 
 #define KTX_FILE_STREAM_MAX (1 << (sizeof(ktx_off_t) - 1) - 1)


### PR DESCRIPTION
The attached patches fix problems with the compilation of vsgXchange for MinGW32 found on openSUSE