### PR TITLE
cmake: Find osg with version support

### DIFF
--- a/src/osg/build_vars.cmake
+++ b/src/osg/build_vars.cmake
@@ -1,10 +1,6 @@
 # Find OpenScenegraph
 set(OSG_MIN_VERSION 3.6)
-find_package(OpenThreads ${OSG_MIN_VERSION})
-find_package(osg ${OSG_MIN_VERSION})
-find_package(osgDB ${OSG_MIN_VERSION})
-find_package(osgTerrain ${OSG_MIN_VERSION})
-find_package(osgUtil ${OSG_MIN_VERSION})
+find_package(OpenSceneGraph ${OSG_MIN_VERSION} REQUIRED OpenThreads osg osgDB osgTerrain osgUtil)
 
 if(OSG_FOUND AND OSGDB_FOUND AND OSGTERRAIN_FOUND AND OSGUTIL_FOUND)
     OPTION(vsgXchange_OSG "Optional OpenSceneGraph support provided" ON)
@@ -25,7 +21,7 @@ if (${vsgXchange_OSG})
     set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${OSG_INCLUDE_DIR})
     set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${OPENTHREADS_LIBRARIES} ${OSG_LIBRARIES} ${OSGUTIL_LIBRARIES} ${OSGDB_LIBRARIES} ${OSGTERRAIN_LIBRARIES})
     if(NOT BUILD_SHARED_LIBS)
-        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(OpenThreads)" "find_dependency(osg)" "find_dependency(osgDB)" "find_dependency(osgTerrain)" "find_dependency(osgUtil)")
+        set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(OpenSceneGraph ${OSG_MIN_VERSION} REQUIRED OpenThreads osg osgDB osgTerrain osgUtil)")
     endif()
 else()
     set(SOURCES ${SOURCES}


### PR DESCRIPTION
The previously used find_package calls do not support version checking.

Fixes #73