### PR TITLE
cmake: let the search for vsg use the same version as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,11 @@ if (VULKAN_SDK)
     set(ENV{VULKAN_SDK} ${VULKAN_SDK})
 endif()
 
-find_package(vsg 0.2.1 REQUIRED)
+set(VSG_MIN_VERSION 0.2.1)
+find_package(vsg ${VSG_MIN_VERSION} REQUIRED)
+
+# for generated cmake support files
+set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(vsg ${VSG_MIN_VERSION} REQUIRED)")
 
 vsg_setup_build_vars()
 vsg_setup_dir_vars()

--- a/src/vsgXchangeConfig.cmake.in
+++ b/src/vsgXchangeConfig.cmake.in
@@ -1,6 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(vsg)
 @FIND_DEPENDENCY_OUT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/vsgXchangeTargets.cmake")


### PR DESCRIPTION
This prevents client packages from finding an older version