### PR TITLE
Check faces for 3 vertices to reject lines and points

### DIFF
--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -394,6 +394,9 @@ vsg::ref_ptr<vsg::Object> assimp::Implementation::processScene(const aiScene* sc
                 {
                     const auto& face = mesh->mFaces[j];
 
+                    // A face can contain points, lines and triangles, having 1, 2 & 3 indicies respectively
+                    // We need to query the number of indicies and build the appropriate primitives in VSG
+                    // TODO: Add point and line primitives. At present we can only deal with triangles, so ignore others.
                     if(face.mNumIndices != 3) continue;
 
                     for (unsigned int k = 0; k < face.mNumIndices; ++k)

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -1,6 +1,6 @@
 /* <editor-fold desc="MIT License">
 
-Copyright(c) 2021 Andr� Normann & Robert Osfield
+Copyright(c) 2021 André Normann & Robert Osfield
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -1,6 +1,6 @@
 /* <editor-fold desc="MIT License">
 
-Copyright(c) 2021 André Normann & Robert Osfield
+Copyright(c) 2021 Andrï¿½ Normann & Robert Osfield
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -393,6 +393,8 @@ vsg::ref_ptr<vsg::Object> assimp::Implementation::processScene(const aiScene* sc
                 for (unsigned int j = 0; j < mesh->mNumFaces; ++j)
                 {
                     const auto& face = mesh->mFaces[j];
+
+                    if(face.mNumIndices != 3) continue;
 
                     for (unsigned int k = 0; k < face.mNumIndices; ++k)
                         indices.push_back(face.mIndices[k]);


### PR DESCRIPTION
DXF file shows artefacts, probably due to lines and points being misinterpreted as faces.

vsgXchange doesn't yet support lines, points & text. We need to check the aiFace structure to ensure the number of vertices is 3, otherwise reject the face. This is a temporary fix until line, point support is added.

Note that it's also possible to set a configuration parameter to reject lines and points. The suggested method is preferred because later line/point support can build from it.

Tested with problematic DXF file on Kubuntu.
