### PR TITLE
Add include to prevent errors

### DIFF
--- a/src/curl/curl.cpp
+++ b/src/curl/curl.cpp
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 using namespace vsgXchange;
 


### PR DESCRIPTION
Fixes the following error on Kubuntu 20.04

/home/roland/Source/vsgXchange/src/curl/curl.cpp:202:23: error: aggregate ‘std::stringstream sstr’ has incomplete type and cannot be defined
  202 |     std::stringstream sstr;
