### PR TITLE
Correctly choose metallic roughness or specular glossy

### DIFF
--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -303,7 +303,8 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
     auto& defines = convertedMaterial.defines;
 
     vsg::PbrMaterial pbr;
-    bool hasPbrSpecularGlossiness = material->Get(AI_MATKEY_COLOR_SPECULAR, pbr.specularFactor);
+    bool hasPbrSpecularGlossiness
+        = material->Get(AI_MATKEY_COLOR_SPECULAR, pbr.specularFactor) == AI_SUCCESS;
 
     convertedMaterial.blending = hasAlphaBlend(material);
 


### PR DESCRIPTION
The Specular Glossiness workpath was always being chosen, which was causing the rendering of most glTF models to be subtly wrong.
before:
![bad](https://user-images.githubusercontent.com/133121/203990793-63e3ca6b-a388-4ebe-b242-c63a53f45e9b.png)
after:
![good](https://user-images.githubusercontent.com/133121/203990821-97d362fe-f510-4633-9d4c-96c1ecc62def.png)
