### PR TITLE
Now choose specular/glossiness when needed

### DIFF
--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -303,8 +303,7 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
     auto& defines = convertedMaterial.defines;
 
     vsg::PbrMaterial pbr;
-    bool hasPbrSpecularGlossiness
-        = material->Get(AI_MATKEY_COLOR_SPECULAR, pbr.specularFactor) == AI_SUCCESS;
+    bool hasPbrSpecularGlossiness = getColor(material, AI_MATKEY_COLOR_SPECULAR, pbr.specularFactor);
 
     convertedMaterial.blending = hasAlphaBlend(material);
 


### PR DESCRIPTION
Use the utility function getColor() instead of the assimp material member function. That was failing due to a data size mismatch.

Sorry for all the churn! I didn't really see what was going on when I made the first fix for metallic/roughness. The two material models seem to display correctly now:

![Screenshot from 2022-11-25 19-26-44](https://user-images.githubusercontent.com/133121/204039482-9b5fd329-aca0-41e8-aaa3-4087d2a1e9fc.png)
