### PR TITLE
#141 vsgconv build error on Windows

### DIFF
--- a/src/ktx/libktx/texture2.c
+++ b/src/ktx/libktx/texture2.c
@@ -22,8 +22,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <zstd.h>
-#include <zstd_errors.h>
+#include "zstd.h"
+#include "zstd_errors.h"
 #include <KHR/khr_df.h>
 
 #include "dfdutils/dfd.h"


### PR DESCRIPTION
#141 vsgconv build error on Windows during linking with dependencies from vcpkg