### PR TITLE
 #143 vsgconv ignores empty transforms 

### DIFF
--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -287,7 +287,6 @@ int main(int argc, char** argv)
     }
 
     if (arguments.read("--rgb")) options->mapRGBtoRGBAHint = false;
-    
     // read any command line options that the ReaderWrite support
     arguments.read(options);
     if (argc <= 1) return 0;

--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -287,6 +287,7 @@ int main(int argc, char** argv)
     }
 
     if (arguments.read("--rgb")) options->mapRGBtoRGBAHint = false;
+
     // read any command line options that the ReaderWrite support
     arguments.read(options);
     if (argc <= 1) return 0;

--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -278,19 +278,16 @@ int main(int argc, char** argv)
         std::cout << "    vsgconv input_filename output_filefilename\n";
         std::cout << "    vsgconv input_filename_1 input_filefilename_2 output_filefilename\n";
         std::cout << "Options:\n";
-        std::cout << "    --features             # list all ReaderWriters and the formats supported\n";
-        std::cout << "    --features rw_name     # list formats sipportred \n";
-        std::cout << "    --nc --no-compile      # do not compile shaders to SPIRV\n";
-        std::cout << "    --rgb                  # leave RGB source data in it's original form rather than converting to RGBA \n";
-        std::cout << "    --honour-empty-nodes   # leave empty nodes in scene graph \n";
-        std::cout << "    -v --version           # report version \n";
+        std::cout << "    --features          # list all ReaderWriters and the formats supported\n";
+        std::cout << "    --features rw_name  # list formats sipportred \n";
+        std::cout << "    --nc --no-compile   # do not compile shaders to SPIRV\n";
+        std::cout << "    --rgb               # leave RGB source data in it's original form rather than converting to RGBA \n";
+        std::cout << "    -v --version        # report version \n";
         return 1;
     }
 
     if (arguments.read("--rgb")) options->mapRGBtoRGBAHint = false;
-
-    options->setValue("honour-empty-nodes", arguments.read("--honour-empty-nodes"));
-
+    
     // read any command line options that the ReaderWrite support
     arguments.read(options);
     if (argc <= 1) return 0;

--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv)
 
     if (arguments.read("--rgb")) options->mapRGBtoRGBAHint = false;
 
-	options->setValue("honour-empty-nodes", arguments.read("--honour-empty-nodes"));
+    options->setValue("honour-empty-nodes", arguments.read("--honour-empty-nodes"));
 
     // read any command line options that the ReaderWrite support
     arguments.read(options);

--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -278,15 +278,18 @@ int main(int argc, char** argv)
         std::cout << "    vsgconv input_filename output_filefilename\n";
         std::cout << "    vsgconv input_filename_1 input_filefilename_2 output_filefilename\n";
         std::cout << "Options:\n";
-        std::cout << "    --features          # list all ReaderWriters and the formats supported\n";
-        std::cout << "    --features rw_name  # list formats sipportred \n";
-        std::cout << "    --nc --no-compile   # do not compile shaders to SPIRV\n";
-        std::cout << "    --rgb               # leave RGB source data in it's original form rather than converting to RGBA \n";
-        std::cout << "    -v --version        # report version \n";
+        std::cout << "    --features             # list all ReaderWriters and the formats supported\n";
+        std::cout << "    --features rw_name     # list formats sipportred \n";
+        std::cout << "    --nc --no-compile      # do not compile shaders to SPIRV\n";
+        std::cout << "    --rgb                  # leave RGB source data in it's original form rather than converting to RGBA \n";
+        std::cout << "    --honour-empty-nodes   # leave empty nodes in scene graph \n";
+        std::cout << "    -v --version           # report version \n";
         return 1;
     }
 
     if (arguments.read("--rgb")) options->mapRGBtoRGBAHint = false;
+
+	options->setValue("honour-empty-nodes", arguments.read("--honour-empty-nodes"));
 
     // read any command line options that the ReaderWrite support
     arguments.read(options);

--- a/include/vsgXchange/models.h
+++ b/include/vsgXchange/models.h
@@ -54,7 +54,7 @@ namespace vsgXchange
         static constexpr const char* generate_sharp_normals = "generate_sharp_normals";
         static constexpr const char* crease_angle = "crease_angle"; /// float
         static constexpr const char* two_sided = "two_sided";       ///  bool
-        static constexpr const char* honour_empty_nodes = "honour_empty_nodes"; /// bool
+        static constexpr const char* discard_empty_nodes = "discard_empty_nodes"; /// bool
 
         bool readOptions(vsg::Options& options, vsg::CommandLine& arguments) const override;
 

--- a/include/vsgXchange/models.h
+++ b/include/vsgXchange/models.h
@@ -54,6 +54,7 @@ namespace vsgXchange
         static constexpr const char* generate_sharp_normals = "generate_sharp_normals";
         static constexpr const char* crease_angle = "crease_angle"; /// float
         static constexpr const char* two_sided = "two_sided";       ///  bool
+        static constexpr const char* honour_empty_nodes = "honour_empty_nodes"; /// bool
 
         bool readOptions(vsg::Options& options, vsg::CommandLine& arguments) const override;
 

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -116,6 +116,7 @@ bool assimp::getFeatures(Features& features) const
     features.optionNameTypeMap[assimp::generate_sharp_normals] = vsg::type_name<bool>();
     features.optionNameTypeMap[assimp::crease_angle] = vsg::type_name<float>();
     features.optionNameTypeMap[assimp::two_sided] = vsg::type_name<bool>();
+    features.optionNameTypeMap[assimp::honour_empty_nodes] = vsg::type_name<bool>();
 
     return true;
 }
@@ -126,6 +127,8 @@ bool assimp::readOptions(vsg::Options& options, vsg::CommandLine& arguments) con
     result = arguments.readAndAssign<bool>(assimp::generate_sharp_normals, &options) || result;
     result = arguments.readAndAssign<float>(assimp::crease_angle, &options) || result;
     result = arguments.readAndAssign<bool>(assimp::two_sided, &options) || result;
+    result = arguments.readAndAssign<bool>(assimp::honour_empty_nodes, &options) || result;
+
     return result;
 }
 
@@ -734,12 +737,17 @@ void SceneConverter::convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node)
 vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiScene* in_scene, vsg::ref_ptr<const vsg::Options> in_options, const vsg::Path& ext)
 {
     scene = in_scene;
-    options = in_options;
-    if (!options->getValue("honour-empty-nodes", honourEmptyNodes)) honourEmptyNodes = false;
+    options = in_options;    
+    honourEmptyNodes = false;
 
     std::string name = scene->mName.C_Str();
 
-    if (options) sharedObjects = options->sharedObjects;
+    if (options)
+    {
+        sharedObjects = options->sharedObjects;
+        honourEmptyNodes = vsg::value<bool>(false, assimp::honour_empty_nodes, options);
+    }
+
     if (!sharedObjects) sharedObjects = vsg::SharedObjects::create();
 
     processCameras();

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -735,7 +735,7 @@ vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiScene* in_scene, vsg::ref_
 {
     scene = in_scene;
     options = in_options;
-	if (!options->getValue("honour-empty-nodes", honourEmptyNodes)) honourEmptyNodes = false;
+    if (!options->getValue("honour-empty-nodes", honourEmptyNodes)) honourEmptyNodes = false;
 
     std::string name = scene->mName.C_Str();
 

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -128,7 +128,6 @@ bool assimp::readOptions(vsg::Options& options, vsg::CommandLine& arguments) con
     result = arguments.readAndAssign<float>(assimp::crease_angle, &options) || result;
     result = arguments.readAndAssign<bool>(assimp::two_sided, &options) || result;
     result = arguments.readAndAssign<bool>(assimp::honour_empty_nodes, &options) || result;
-
     return result;
 }
 
@@ -737,7 +736,7 @@ void SceneConverter::convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node)
 vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiScene* in_scene, vsg::ref_ptr<const vsg::Options> in_options, const vsg::Path& ext)
 {
     scene = in_scene;
-    options = in_options;    
+    options = in_options;
     honourEmptyNodes = false;
 
     std::string name = scene->mName.C_Str();

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -159,14 +159,14 @@ struct SceneConverter
     static vsg::vec3 convert(const aiColor3D& v) { return vsg::vec3(v[0], v[1], v[2]); }
     static vsg::vec4 convert(const aiColor4D& v) { return vsg::vec4(v[0], v[1], v[2], v[3]); }
     
-	static vsg::ref_ptr<vsg::MatrixTransform> nodeToTransform(const aiNode* node)
+    static vsg::ref_ptr<vsg::MatrixTransform> nodeToTransform(const aiNode* node)
     {
         std::string name = node->mName.C_Str();
         aiMatrix4x4 m = node->mTransformation;
         m.Transpose();
         auto transform = vsg::MatrixTransform::create(vsg::dmat4(vsg::mat4((float*)&m)));
         if (!name.empty()) transform->setValue("name", name);        
-		return transform;
+        return transform;
     }
 
     static bool getColor(const aiMaterial* material, const char *pKey, unsigned int type, unsigned int idx, vsg::vec3& value)

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -160,16 +160,6 @@ struct SceneConverter
     static vsg::dvec3 dconvert(const aiVector3D& v) { return vsg::dvec3(v[0], v[1], v[2]); }
     static vsg::vec3 convert(const aiColor3D& v) { return vsg::vec3(v[0], v[1], v[2]); }
     static vsg::vec4 convert(const aiColor4D& v) { return vsg::vec4(v[0], v[1], v[2], v[3]); }
-    
-    static vsg::ref_ptr<vsg::MatrixTransform> nodeToTransform(const aiNode* node)
-    {
-        std::string name = node->mName.C_Str();
-        aiMatrix4x4 m = node->mTransformation;
-        m.Transpose();
-        auto transform = vsg::MatrixTransform::create(vsg::dmat4(vsg::mat4((float*)&m)));
-        if (!name.empty()) transform->setValue("name", name);        
-        return transform;
-    }
 
     static bool getColor(const aiMaterial* material, const char *pKey, unsigned int type, unsigned int idx, vsg::vec3& value)
     {
@@ -841,11 +831,7 @@ vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiNode* node, int depth)
         }
     }
 
-    if (children.empty())
-    {
-        if (honourEmptyNodes) return nodeToTransform(node);
-        return {};
-    }
+    if (children.empty() && !honourEmptyNodes) return {};
 
     if (!honourEmptyNodes && node->mTransformation.IsIdentity())
     {
@@ -859,8 +845,12 @@ vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiNode* node, int depth)
     }
     else
     {
-        auto transform = nodeToTransform(node);
+        aiMatrix4x4 m = node->mTransformation;
+        m.Transpose();
+
+        auto transform = vsg::MatrixTransform::create(vsg::dmat4(vsg::mat4((float*)&m)));
         transform->children = children;
+        if (!name.empty()) transform->setValue("name", name);
 
         // TODO check if subgraph requires culling
         //transform->subgraphRequiresLocalFrustum = false;


### PR DESCRIPTION
Added command line parameter --honour-empty-nodes to vsgconv to include nodes that doesn't have children or transform matrix is identity. By default old behaviour is preserved.