### PR TITLE
add missing header

### DIFF
--- a/src/openexr/openexr.cpp
+++ b/src/openexr/openexr.cpp
@@ -10,6 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <cstdint>
+
 #include <vsg/io/FileSystem.h>
 #include <vsg/io/stream.h>
 #include <vsgXchange/images.h>


### PR DESCRIPTION
Hi,

Trying to compile this on Archlinux, I get the following issues:
```
[1/3] Building CXX object src/CMakeFiles/vsgXchange.dir/openexr/openexr.cpp.o
FAILED: src/CMakeFiles/vsgXchange.dir/openexr/openexr.cpp.o 
sccache /usr/bin/g++ -DASSIMP_VERSION_MAJOR=5 -DASSIMP_VERSION_MINOR=2 -DASSIMP_VERSION_PATCH=4 -DBASISD_SUPPORT_FXT1=0 -DBASISU_NO_ITERATOR_DEBUG_LEVEL -DEXRVERSION3 -DKHRONOS_STATIC -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DLIBKTX -DUSE_FREETYPE -DUSE_GDAL -I/home/nim/aur/vsgxchange/src/vsgXchange-1.0.3/include -I/home/nim/aur/vsgxchange/src/build-1.0.3/include -I/usr/include/freetype2 -I/home/nim/aur/vsgxchange/src/vsgXchange-1.0.3/src/ktx/libktx -isystem /usr/include/OpenEXR -isystem /usr/include/Imath -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -O2 -g -DNDEBUG -std=gnu++17 -fPIC -fdiagnostics-color=always -Wall -Wparentheses -Wno-long-long -Wno-import -Wreturn-type -Wmissing-braces -Wunknown-pragmas -Wmaybe-uninitialized -Wshadow -Wunused -Wno-misleading-indentation -Wextra -MD -MT src/CMakeFiles/vsgXchange.dir/openexr/openexr.cpp.o -MF src/CMakeFiles/vsgXchange.dir/openexr/openexr.cpp.o.d -o src/CMakeFiles/vsgXchange.dir/openexr/openexr.cpp.o -c /home/nim/aur/vsgxchange/src/vsgXchange-1.0.3/src/openexr/openexr.cpp
In file included from /usr/include/vsg/maths/vec3.h:26,
                 from /usr/include/vsg/maths/box.h:15,
                 from /usr/include/vsg/io/stream.h:18,
                 from /home/nim/aur/vsgxchange/src/vsgXchange-1.0.3/src/openexr/openexr.cpp:14:
/usr/include/vsg/maths/vec2.h:139:31: error: 'int8_t' is not a member of 'std'; did you mean 'wint_t'?
  139 |     using bvec2 = t_vec2<std::int8_t>;    // signed 8 bit integer 2D vector
      |                               ^~~~~~
      |                               wint_t
/usr/include/vsg/maths/vec2.h:139:37: error: template argument 1 is invalid
  139 |     using bvec2 = t_vec2<std::int8_t>;    // signed 8 bit integer 2D vector
      |                                     ^
/usr/include/vsg/maths/vec2.h:140:31: error: 'int16_t' is not a member of 'std'; did you mean 'int16_t'?
  140 |     using svec2 = t_vec2<std::int16_t>;   //  signed 16 bit integer 2D vector
      |                               ^~~~~~~
```

I guess it's because `std::int8_t` is declared in `cstdint`: https://en.cppreference.com/w/cpp/types/integer