### PR TITLE
Changed vsgconv to handle missing output_filename argument

### DIFF
--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -328,16 +328,16 @@ int main(int argc, char** argv)
     auto numThreads = arguments.value(16, "-t");
     bool compileShaders = !arguments.read({"--no-compile", "--nc"});
 
-    vsg::Path outputFilename = arguments[argc - 1];
-
-    using VsgObjects = std::vector<vsg::ref_ptr<vsg::Object>>;
-    VsgObjects vsgObjects;
-
     if (argc <= 2)
     {
         std::cout << "No output file specified." << std::endl;
         return 1;
     }
+
+    vsg::Path outputFilename = arguments[argc - 1];
+
+    using VsgObjects = std::vector<vsg::ref_ptr<vsg::Object>>;
+    VsgObjects vsgObjects;
 
     // read any input files
     for (int i = 1; i < argc - 1; ++i)

--- a/applications/vsgconv/vsgconv.cpp
+++ b/applications/vsgconv/vsgconv.cpp
@@ -333,6 +333,12 @@ int main(int argc, char** argv)
     using VsgObjects = std::vector<vsg::ref_ptr<vsg::Object>>;
     VsgObjects vsgObjects;
 
+    if (argc <= 2)
+    {
+        std::cout << "No output file specified." << std::endl;
+        return 1;
+    }
+
     // read any input files
     for (int i = 1; i < argc - 1; ++i)
     {


### PR DESCRIPTION
The vsgconv tool would fail with a confusing error message if the caller failed to specify the output_filename.

This commit adds a check for the required minimum number of argument before starting to actually parse the input arguments using the ReaderWriters and quits, emitting an appropriate error message, if that number of arguments was not specified.

Fixes #158