### PR TITLE
[FIXED] removed warning

### DIFF
--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -717,7 +717,7 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
     double total_nearest_edge = 0.0;
     double total_outside_edge = 0.0;
 
-    auto glyphMetrics = vsg::GlyphMetricsArray::create(sortedGlyphQuads.size() + 1);
+    auto glyphMetrics = vsg::GlyphMetricsArray::create((uint32_t)(sortedGlyphQuads.size() + 1));
     auto charmap = vsg::uintArray::create(max_charcode + 1);
     uint32_t destation_glyphindex = 0;
 

--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -717,7 +717,7 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
     double total_nearest_edge = 0.0;
     double total_outside_edge = 0.0;
 
-    auto glyphMetrics = vsg::GlyphMetricsArray::create((uint32_t)(sortedGlyphQuads.size() + 1));
+    auto glyphMetrics = vsg::GlyphMetricsArray::create(static_cast<uint32_t>(sortedGlyphQuads.size()) + 1));
     auto charmap = vsg::uintArray::create(max_charcode + 1);
     uint32_t destation_glyphindex = 0;
 


### PR DESCRIPTION
In MSVS, 'warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data'