### PR TITLE
[FIXED] build warnings

### DIFF
--- a/src/curl/curl_fallback.cpp
+++ b/src/curl/curl_fallback.cpp
@@ -18,7 +18,7 @@ using namespace vsgXchange;
 //
 // curl ReaderWriter fallback
 //
-struct curl::Implementation
+class curl::Implementation
 {
 };
 curl::curl() :

--- a/src/freetype/freetype_fallback.cpp
+++ b/src/freetype/freetype_fallback.cpp
@@ -18,7 +18,7 @@ using namespace vsgXchange;
 //
 // freetype ReaderWriter fallback
 //
-struct freetype::Implementation
+class freetype::Implementation
 {
 };
 freetype::freetype() :


### PR DESCRIPTION
Seen in MSVS

warning C4099: 'vsgXchange::freetype::Implementation': type name first seen using 'class' now seen using 'struct'
warning C4099: 'vsgXchange::curl::Implementation': type name first seen using 'class' now seen using 'struct'