### PR TITLE
Optional texture embedding

### DIFF
--- a/include/vsgXchange/models.h
+++ b/include/vsgXchange/models.h
@@ -54,6 +54,8 @@ namespace vsgXchange
         static constexpr const char* crease_angle = "crease_angle"; /// float
         static constexpr const char* two_sided = "two_sided";       ///  bool
         static constexpr const char* discard_empty_nodes = "discard_empty_nodes"; /// bool
+        static constexpr const char* external_textures = "external_textures";   /// bool
+        static constexpr const char* external_texture_format = "external_texture_format";   // TextureFormat
 
         bool readOptions(vsg::Options& options, vsg::CommandLine& arguments) const override;
 

--- a/include/vsgXchange/models.h
+++ b/include/vsgXchange/models.h
@@ -55,7 +55,7 @@ namespace vsgXchange
         static constexpr const char* two_sided = "two_sided";       ///  bool
         static constexpr const char* discard_empty_nodes = "discard_empty_nodes"; /// bool
         static constexpr const char* external_textures = "external_textures";   /// bool
-        static constexpr const char* external_texture_format = "external_texture_format";   // TextureFormat
+        static constexpr const char* external_texture_format = "external_texture_format";   /// TextureFormat enum
 
         bool readOptions(vsg::Options& options, vsg::CommandLine& arguments) const override;
 

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -792,7 +792,7 @@ vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiScene* in_scene, vsg::ref_
 
     if (options) sharedObjects = options->sharedObjects;
     if (!sharedObjects) sharedObjects = vsg::SharedObjects::create();
-    if (!externalObjects) externalObjects = vsg::External::create();
+    if (externalTextures && !externalObjects) externalObjects = vsg::External::create();
 
     processCameras();
     processLights();
@@ -1095,13 +1095,14 @@ vsg::ref_ptr<vsg::Object> assimp::Implementation::read(const vsg::Path& filename
             SceneConverter converter;
             converter.filename = filename;
 
-            if (auto root = converter.visit(scene, opt, ext))
+            auto root = converter.visit(scene, opt, ext);
+            if (root)
             {
                 if (converter.externalTextures && converter.externalObjects && !converter.externalObjects->entries.empty())
                     root->setObject("external", converter.externalObjects);
-
-                return root;
             }
+
+            return root;
         }
         else
         {

--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -357,7 +357,7 @@ SamplerData SceneConverter::convertTexture(const aiMaterial& material, aiTexture
             switch (externalTextureFormat)
             {
             case TextureFormat::native:
-                break;  /// nothing to do
+                break;  // nothing to do
             case TextureFormat::vsgt:
                 externalTextureFilename = vsg::removeExtension(externalTextureFilename).concat(".vsgt");
                 break;
@@ -372,7 +372,7 @@ SamplerData SceneConverter::convertTexture(const aiMaterial& material, aiTexture
                 switch (externalTextureFormat)
                 {
                 case TextureFormat::native:
-                    break;  /// nothing to do
+                    break;  // nothing to do
                 case TextureFormat::vsgt:
                     vsg::write(samplerImage.data, externalTextureFilename, options);
                     break;


### PR DESCRIPTION
The vsgXchange::assimp ReaderWriter now offers the option of not embedding texture files into the generated vsg native file. This is done by setting the external_textures option to true. Note that this does not work for textures already embedded within the source model!

In addition, by suppling the external_texture_format command line option, it is possible to specify whether the stand-alone texture files should be saved in the vsg-native format (either vsgt or vsga). By dong this there is no need for the integrating application to link against vsgXchange for texture conversion.

This leverages the vsg::External object, see [this discussion](https://github.com/vsg-dev/VulkanSceneGraph/discussions/982).

One thing I am unsure about is that currently only the vsg::Image is being loaded from external file, but the associated vsg::Sampler is still embedded within the file and not recalculated if the image is being loaded, which could be problematic if that external file has some properties changed (like the number of included mipmaps..)