### PR TITLE
Add Doxygen html directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ vsgXchangeConfig.cmake
 vsgXchangeConfigVersion.cmake
 Doxyfile.docs-vsgXchange
 
+html/
+
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
It's already there for the main repo, but not for the ancillary ones.

I've not got to vsgImGui yet but need to go and do something else now, so it's not coming in the next hour or so.