### PR TITLE
Don't share descriptors or descriptor sets

### DIFF
--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -481,18 +481,6 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
 
         convertedMaterial.assignDescriptor("material", vsg::PhongMaterialValue::create(mat));
     }
-
-    if (sharedObjects)
-    {
-        for(auto& ds : convertedMaterial.descriptorSets)
-        {
-            if (ds)
-            {
-                sharedObjects->share(ds->descriptors);
-                sharedObjects->share(ds);
-            }
-        }
-    }
 }
 
 vsg::ref_ptr<vsg::Data> SceneConverter::createIndices(const aiMesh* mesh, unsigned int numIndicesPerFace, uint32_t numIndices)
@@ -871,7 +859,7 @@ void SceneConverter::processLights()
 {
     if (scene->mNumLights > 0)
     {
-        auto setColorAndIntensity = [](const aiLight& light, vsg::Light& vsg_light) -> void
+        auto setColorAndIntensity = [this](const aiLight& light, vsg::Light& vsg_light) -> void
         {
             vsg_light.color = convert(light.mColorDiffuse);
             float maxValue = std::max(std::max(vsg_light.color.r, vsg_light.color.g),  vsg_light.color.b);


### PR DESCRIPTION
Calling sharedObjects->share() on descriptor sets was resulting in shared structure that would royally screw up the later calls to vsg::DescriptorConfigurator::assignDefaults().