### PR TITLE
Fix to pass "Alpha Blend Mode Test"

### DIFF
--- a/src/assimp/assimp.cpp
+++ b/src/assimp/assimp.cpp
@@ -367,6 +367,10 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
         getColor(material, AI_MATKEY_COLOR_EMISSIVE, pbr.emissiveFactor);
         material->Get(AI_MATKEY_GLTF_ALPHACUTOFF, pbr.alphaMaskCutoff);
 
+        aiString alphaMode;
+        if (material->Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode) == AI_SUCCESS && alphaMode == aiString("OPAQUE"))
+            pbr.alphaMaskCutoff = 0.0f;
+
         SamplerData samplerImage;
         if (samplerImage = convertTexture(*material, aiTextureType_DIFFUSE); samplerImage.data.valid())
         {


### PR DESCRIPTION
# Pull Request Template

## Description

Make a fix to successfully pass the glTF-AlphaBlendModeTest. When importing an opaque material, it is needed to set "pbr.alphaMaskCutoff" to zero. Otherwise the default value of 0.5 would be used, which is wrong for an opaque material.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested against this model: [AlphaBlendModeTest](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AlphaBlendModeTest)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules