### PR TITLE
Changed the order of the include folders

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,8 +65,8 @@ target_compile_definitions(vsgXchange PRIVATE ${EXTRA_DEFINES})
 
 target_include_directories(vsgXchange
     PUBLIC
-        $<BUILD_INTERFACE:${VSGXCHANGE_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${VSGXCHANGE_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${VSGXCHANGE_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${EXTRA_INCLUDES}


### PR DESCRIPTION
So I am not 100% sure what is going on here (probably not the right way to start a PR description ;))

I am using cmake to generate VS2022 project files, and configured it to have an explicit 'binary' folder (-B ./build/_windows), which makes cmake put the 'configured' Version.h file into (".\build\_windows\include\vsgXchange\Version.h"). Now, however, in the Visual Studio's project files (as generated by cmake), the include folders are set in the following order:

1. X:\vsgXchange\include
2. X:\vsgXchange\build\_windows\include
3. X:\vsgXchange\src\ktx\libktx

Which means that the 'non-configured' Version.h will be 'found' first.. but the problem is that this file does NONE of the 'optional features' defined, ie it looks like this:

>     /// optional Features
>/* #undef vsgXchange_curl */
>/* #undef vsgXchange_openexr */
>/* #undef vsgXchange_freetype */
>/* #undef vsgXchange_assimp */
>/* #undef vsgXchange_GDAL */
>/* #undef vsgXchange_OSG */

While my 'configured' one looks like this

>     /// optional Features
>    #define vsgXchange_curl
>/* #undef vsgXchange_openexr */
>    #define vsgXchange_freetype
>    #define vsgXchange_assimp
>    #define vsgXchange_GDAL
>/* #undef vsgXchange_OSG */

In my opinion the 'configured' #include should be FIRST in the search order, so that the symbols for the optional components are correctly set.

Why this (seems to) compile for everyone else I don't understand, maybe this is due to me (mis)using the -B option for cmake? Probably, if the '-B' option is not specified, the 'configured' include will simply overwrite the 'source' version?