### PR TITLE
Update README.md to include Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ In source build:
 
 ### Windows:
 
-To be filled in by a kindly Windows dev :-)
+Using cmake:
+```
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
 
 ## How to use vsgXchange in your own applications
 


### PR DESCRIPTION
Adding these instructions to help Windows users out.

Building with cmake is extremely easy, and recommended! It helps with standalone and modularized builds.