### PR TITLE
Hide zstd library symbols

### DIFF
--- a/src/ktx/libktx/ktx_zstd.h
+++ b/src/ktx/libktx/ktx_zstd.h
@@ -22,7 +22,7 @@ extern "C" {
 /* =====   ZSTDLIB_API : control library symbols visibility   ===== */
 #ifndef ZSTDLIB_VISIBILITY
 #  if defined(__GNUC__) && (__GNUC__ >= 4)
-#    define ZSTDLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#    define ZSTDLIB_VISIBILITY __attribute__ ((visibility ("hidden")))
 #  else
 #    define ZSTDLIB_VISIBILITY
 #  endif

--- a/src/ktx/libktx/ktx_zstd_errors.h
+++ b/src/ktx/libktx/ktx_zstd_errors.h
@@ -22,7 +22,7 @@ extern "C" {
 /* =====   ZSTDERRORLIB_API : control library symbols visibility   ===== */
 #ifndef ZSTDERRORLIB_VISIBILITY
 #  if defined(__GNUC__) && (__GNUC__ >= 4)
-#    define ZSTDERRORLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#    define ZSTDERRORLIB_VISIBILITY __attribute__ ((visibility ("hidden")))
 #  else
 #    define ZSTDERRORLIB_VISIBILITY
 #  endif

--- a/src/ktx/libktx/texture2.c
+++ b/src/ktx/libktx/texture2.c
@@ -22,8 +22,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include "zstd.h"
-#include "zstd_errors.h"
+#include "ktx_zstd.h"
+#include "ktx_zstd_errors.h"
 #include <KHR/khr_df.h>
 
 #include "dfdutils/dfd.h"


### PR DESCRIPTION
The ktx library required libzstd symbols for interal work but was not hiding them. This caused symbol conflicts with the dynamic loader if other shared libraries loaded the system's libzstd.so.1 library.

issue #193 