### PR TITLE
Fixed 'Optional Texture Embedding' feature

### DIFF
--- a/src/assimp/SceneConverter.cpp
+++ b/src/assimp/SceneConverter.cpp
@@ -424,10 +424,10 @@ SamplerData SceneConverter::convertTexture(const aiMaterial& material, aiTexture
         }
         else
         {
-            auto textureFilename = vsg::findFile(texPath.C_Str(), options);
-            if (samplerImage.data = vsg::read_cast<vsg::Data>(textureFilename, options); !samplerImage.data.valid())
+            externalTextureFilename = vsg::findFile(texPath.C_Str(), options);
+            if (samplerImage.data = vsg::read_cast<vsg::Data>(externalTextureFilename, options); !samplerImage.data.valid())
             {
-                vsg::warn("Failed to load texture: ", textureFilename, " texPath = ", texPath.C_Str());
+                vsg::warn("Failed to load texture: ", externalTextureFilename, " texPath = ", texPath.C_Str());
                 return {};
             }
         }


### PR DESCRIPTION
## Description

It seems that commit https://github.com/vsg-dev/vsgXchange/commit/68edd8f22af38cdd883e2cf81c1652b6031c8e94 broke the 'Optional texture embedding' (see PR https://github.com/vsg-dev/vsgXchange/pull/172) feature, so that vsgb/vsgt files created using vsgconv will (at best) not work and (at worst) lead to the loading code to crash.

For example it happened to me that I had a top-level CullNode.. the vsg::External object referenced an external texture, but its path was not set/saved (that is the actual bug introduced in the merge), so the StartID_EndID_Filename values were incorrect (an empty object with the ID=3 was created on loading), which means the the vsg::MatrixTransform node was not loaded (since the empty object with ID=3 already cached), so I ended up with a CullNode without child node, which leads to an access violation on traversal (CullNode on purpose does not check for this due to performance considerations)

> #vsga 1.1.7
Root id=1 vsg::CullNode
{
  userObjects 1
  key "external"
  object id=2 vsg::External
  {
    userObjects 0
    options id=0
    NumEntries 1
    StartID_EndID_Filename 3 3 ""
  }
  bound 2.28881835938e-05 2.22340196371 45.2545385361 63.7056769332
  child id=3 vsg::MatrixTransform
  {

For reference, after the fix, the file looks like this

> #vsga 1.1.7
Root id=1 vsg::CullNode
{
  userObjects 1
  key "external"
  object id=2 vsg::External
  {
    userObjects 0
    options id=0
    NumEntries 1
    StartID_EndID_Filename 3 4 "myTexture.bmp"
  }
  bound 2.28881835938e-05 2.22340196371 45.2545385361 63.7056769332
  child id=4 vsg::MatrixTransform
  {

Fixes #195

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I converted some test models using vsgconvd.exe, using the command line
- [X] '--external_textures true --external_texture_format vsgb' and 
- [X] '--external_textures true --external_texture_format native'

then loaded the resulting files into the vsgViewer example

**Test Configuration**:
Windows 10, VS2022

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
