### PR TITLE
Fix issue when searching metadata and comparing result with deprecated AI_SUCCESS

### DIFF
--- a/src/assimp/SceneConverter.cpp
+++ b/src/assimp/SceneConverter.cpp
@@ -1594,7 +1594,7 @@ vsg::ref_ptr<vsg::MatrixTransform> SceneConverter::processCoordinateFrame(const 
     if (scene->mMetaData)
     {
         int upAxis = 1;
-        if (scene->mMetaData->Get("UpAxis", upAxis) == AI_SUCCESS)
+        if (scene->mMetaData->Get("UpAxis", upAxis))
         {
             if (upAxis == 0)
                 source_coordinateConvention = vsg::CoordinateConvention::X_UP;


### PR DESCRIPTION
I have produced some obj and stl files with Z_UP axis convention. When I import them using vsgXchange the axis convention is switched to Y_UP, resulting in them not displaying in the correct place. This has been traced to the problem outlined below.

SceneConverter attempts to determine the up axis convention of assets by searching metadata for "UpAxis". If found, the upAxis is set to the variable upAxis, which is initialised to 1 (the Assimp equivalent of Y_UP).

Success of the metadata search is determined by comparing the returned result to AI_SUCCESS.
`if (scene->mMetaData->Get("UpAxis", upAxis) == AI_SUCCESS)`

This is incorrect because Get() returns true on success and false on failure. AI_SUCCESS is defined as 0. See the code from Assimp types.h below. Note the comment near the bottom that says AI_SUCCESS is for backward compatibility and should not be used anymore. The current code will force the axis convention to be Y_UP in most circumstances. This PR allows options->formatCoordinateConventions to set the up axis convention if it is not defined in the metadata.

Note that AI_SUCCESS is used in other parts of vsgXchange, but I haven't checked validity in those places.

```
// ----------------------------------------------------------------------------------
/** Standard return type for some library functions.
 * Rarely used, and if, mostly in the C API.
 */
typedef enum aiReturn {
    /** Indicates that a function was successful */
    aiReturn_SUCCESS = 0x0,

    /** Indicates that a function failed */
    aiReturn_FAILURE = -0x1,

    /** Indicates that not enough memory was available
     * to perform the requested operation
     */
    aiReturn_OUTOFMEMORY = -0x3,

    /** @cond never
     *  Force 32-bit size enum
     */
    _AI_ENFORCE_ENUM_SIZE = 0x7fffffff

    /// @endcond
} aiReturn; // !enum aiReturn

// just for backwards compatibility, don't use these constants anymore
#define AI_SUCCESS aiReturn_SUCCESS
#define AI_FAILURE aiReturn_FAILURE
#define AI_OUTOFMEMORY aiReturn_OUTOFMEMORY

```

