### PR TITLE
Check AssImp shading model and use it to determine when to use Phong instead of PBR

### DIFF
--- a/src/assimp/SceneConverter.cpp
+++ b/src/assimp/SceneConverter.cpp
@@ -533,7 +533,10 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
         defines.insert("VSG_TWO_SIDED_LIGHTING");
     }
 
-    if (getColor(material, AI_MATKEY_BASE_COLOR, pbr.baseColorFactor) || hasPbrSpecularGlossiness)
+    aiShadingMode shadingMode;
+    material->Get(AI_MATKEY_SHADING_MODEL, shadingMode);
+
+    if (!(shadingMode & aiShadingMode_Phong || shadingMode & aiShadingMode_Blinn) && (getColor(material, AI_MATKEY_BASE_COLOR, pbr.baseColorFactor) || hasPbrSpecularGlossiness))
     {
         // PBR path
         convertedMaterial.shaderSet = getOrCreatePbrShaderSet();
@@ -621,9 +624,6 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
         const auto diffuseResult = getColor(material, AI_MATKEY_COLOR_DIFFUSE, mat.diffuse);
         const auto emissiveResult = getColor(material, AI_MATKEY_COLOR_EMISSIVE, mat.emissive);
         const auto specularResult = getColor(material, AI_MATKEY_COLOR_SPECULAR, mat.specular);
-
-        aiShadingMode shadingModel = aiShadingMode_Phong;
-        material->Get(AI_MATKEY_SHADING_MODEL, shadingModel);
 
         unsigned int maxValue = 1;
         float strength = 1.0f;


### PR DESCRIPTION
There are other AssImp shading models, but some of them aren't things the VSG's got a built-in shader for, and there's some dumbness with the available values as the list of options was originally taken from Blender back when Blender's shading models were total nonsense (e.g. Cook-Torrance was actually Blinn-Phong, Blinn-Phong had some parts of Cook-Torrance added etc.). I've therefore ignored lots of them.

Previously, the value was put into a variable, but then never read, and that only happened on the Phong path, which was more-or-less unreachable as most assimp format loaders set `AI_MATKEY_COLOR_SPECULAR` for the Phong specular colour, so it wasn't a good signal to use to decide that PBR shaders should be used.

Despite fixing a bug in vsgXchange, this might cause bugs in downstream applications that rely on the bug, e.g. ones that provide a custom PBR shader and then load FBX files. That could be dealt with in several ways in such applications, e.g. getting arguably more correct behaviour by also providing a custom Phong shader or providing their existing PBR replacement shader as a Phong replacement shader, too. Alternatively , as AssImp attempts to set best-guess parameters for other shading models (hence why things haven't broken horribly when trying to render FBX files with PBR shaders until now), maybe we could add an option to the loader to force a particular shading model to be used for everything, then it'd be easier to avoid a descriptor mismatch or missing values when using the 'wrong' shader.