### PR TITLE
Convert material and vertex colours from AssImp from sRGB where appropriate

### DIFF
--- a/src/assimp/SceneConverter.cpp
+++ b/src/assimp/SceneConverter.cpp
@@ -14,6 +14,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsgXchange;
 
+namespace
+{
+    [[always_inline, msvc::forceinline]]
+    void convertColor(vsg::vec4& color, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace)
+    {
+        if (sourceColorSpace == vsg::Options::sRGB && destinationColorSpace == vsg::Options::linearRGB)
+            color = vsg::sRGB_to_linear(color);
+        else if (sourceColorSpace == vsg::Options::linearRGB && destinationColorSpace == vsg::Options::sRGB)
+            color = vsg::linear_to_sRGB(color);
+    }
+}
+
 SubgraphStats SceneConverter::collectSubgraphStats(const aiNode* in_node, unsigned int depth)
 {
     SubgraphStats stats;
@@ -519,7 +531,7 @@ SamplerData SceneConverter::convertTexture(const aiMaterial& material, aiTexture
     }
 }
 
-void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial)
+void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace)
 {
     auto& defines = convertedMaterial.defines;
 
@@ -566,6 +578,11 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
 
         getColor(material, AI_MATKEY_COLOR_EMISSIVE, pbr.emissiveFactor);
         material->Get(AI_MATKEY_GLTF_ALPHACUTOFF, pbr.alphaMaskCutoff);
+
+        convertColor(pbr.baseColorFactor, sourceColorSpace, destinationColorSpace);
+        convertColor(pbr.emissiveFactor, sourceColorSpace, destinationColorSpace);
+        convertColor(pbr.diffuseFactor, sourceColorSpace, destinationColorSpace);
+        convertColor(pbr.specularFactor, sourceColorSpace, destinationColorSpace);
 
         aiString alphaMode;
         if (material->Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode) == AI_SUCCESS && alphaMode == aiString("OPAQUE"))
@@ -627,6 +644,11 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
         const auto diffuseResult = getColor(material, AI_MATKEY_COLOR_DIFFUSE, mat.diffuse);
         const auto emissiveResult = getColor(material, AI_MATKEY_COLOR_EMISSIVE, mat.emissive);
         const auto specularResult = getColor(material, AI_MATKEY_COLOR_SPECULAR, mat.specular);
+
+        convertColor(mat.ambient, sourceColorSpace, destinationColorSpace);
+        convertColor(mat.diffuse, sourceColorSpace, destinationColorSpace);
+        convertColor(mat.emissive, sourceColorSpace, destinationColorSpace);
+        convertColor(mat.specular, sourceColorSpace, destinationColorSpace);
 
         unsigned int maxValue = 1;
         float strength = 1.0f;
@@ -743,7 +765,7 @@ vsg::ref_ptr<vsg::Data> SceneConverter::createIndices(const aiMesh* mesh, unsign
     }
 }
 
-void SceneConverter::convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node)
+void SceneConverter::convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace)
 {
     if (convertedMaterials.size() <= mesh->mMaterialIndex)
     {
@@ -866,6 +888,8 @@ void SceneConverter::convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node)
     {
         auto colors = vsg::vec4Array::create(mesh->mNumVertices);
         std::memcpy(colors->dataPointer(), mesh->mColors[0], mesh->mNumVertices * 16);
+        for (auto& color : *colors)
+            convertColor(color, sourceColorSpace, destinationColorSpace);
         config->assignArray(vertexArrays, "vsg_Color", VK_VERTEX_INPUT_RATE_VERTEX, colors);
     }
     else
@@ -1061,18 +1085,25 @@ vsg::ref_ptr<vsg::Node> SceneConverter::visit(const aiScene* in_scene, vsg::ref_
     processLights();
 
     // convert the materials
+    // this is a good heuristic for every format I've checked, but I've not covered all the ~60 formats assimp supports
+    vsg::Options::ColorSpace sourceColorSpace = (ext == ".gltf" || ext == ".glb") ? vsg::Options::linearRGB : vsg::Options::sRGB;
+    if (auto itr = options->formatMaterialColorSpaces.find(ext); itr != options->formatMaterialColorSpaces.end())
+        sourceColorSpace = itr->second;
     convertedMaterials.resize(scene->mNumMaterials);
     for (unsigned int i = 0; i < scene->mNumMaterials; ++i)
     {
         convertedMaterials[i] = vsg::DescriptorConfigurator::create();
-        convert(scene->mMaterials[i], *convertedMaterials[i]);
+        convert(scene->mMaterials[i], *convertedMaterials[i], sourceColorSpace, options->sceneMaterialColorSpace);
     }
 
     // convert the meshes
+    sourceColorSpace = (ext == ".gltf" || ext == ".glb") ? vsg::Options::linearRGB : vsg::Options::sRGB;
+    if (auto itr = options->formatVertexColorColorSpaces.find(ext); itr != options->formatVertexColorColorSpaces.end())
+        sourceColorSpace = itr->second;
     convertedMeshes.resize(scene->mNumMeshes);
     for (unsigned int i = 0; i < scene->mNumMeshes; ++i)
     {
-        convert(scene->mMeshes[i], convertedMeshes[i]);
+        convert(scene->mMeshes[i], convertedMeshes[i], sourceColorSpace, options->sceneVertexColorColorSpace);
     }
 
     auto vsg_scene = visit(scene->mRootNode, 0);

--- a/src/assimp/SceneConverter.h
+++ b/src/assimp/SceneConverter.h
@@ -120,6 +120,7 @@ namespace vsgXchange
         using SubgraphStatsMap = std::map<const aiNode*, SubgraphStats>;
         using BoneStatsMap = std::map<const aiBone*, BoneStats>;
         using BoneTransformMap = std::map<const aiNode*, unsigned int>;
+        using ColorSpace = vsg::Options::ColorSpace;
 
         vsg::Path filename;
 
@@ -140,6 +141,10 @@ namespace vsgXchange
         TextureFormat externalTextureFormat = TextureFormat::native;
         bool sRGBTextures = false;
         bool culling = true;
+        ColorSpace sceneVertexColorColorSpace = ColorSpace::linearRGB;
+        ColorSpace sceneMaterialColorSpace = ColorSpace::linearRGB;
+        ColorSpace sourceVertexColorColorSpace = ColorSpace::sRGB;
+        ColorSpace sourceMaterialColorSpace = ColorSpace::sRGB;
 
         // TODO flatShadedShaderSet?
         vsg::ref_ptr<vsg::ShaderSet> pbrShaderSet;
@@ -239,10 +244,10 @@ namespace vsgXchange
 
         SamplerData convertTexture(const aiMaterial& material, aiTextureType type) const;
 
-        void convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace);
+        void convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial);
 
         vsg::ref_ptr<vsg::Data> createIndices(const aiMesh* mesh, unsigned int numIndicesPerFace, uint32_t numIndices);
-        void convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace);
+        void convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node);
 
         vsg::ref_ptr<vsg::Node> visit(const aiScene* in_scene, vsg::ref_ptr<const vsg::Options> in_options, const vsg::Path& ext);
         vsg::ref_ptr<vsg::Node> visit(const aiNode* node, int depth);

--- a/src/assimp/SceneConverter.h
+++ b/src/assimp/SceneConverter.h
@@ -239,10 +239,10 @@ namespace vsgXchange
 
         SamplerData convertTexture(const aiMaterial& material, aiTextureType type) const;
 
-        void convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial);
+        void convert(const aiMaterial* material, vsg::DescriptorConfigurator& convertedMaterial, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace);
 
         vsg::ref_ptr<vsg::Data> createIndices(const aiMesh* mesh, unsigned int numIndicesPerFace, uint32_t numIndices);
-        void convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node);
+        void convert(const aiMesh* mesh, vsg::ref_ptr<vsg::Node>& node, vsg::Options::ColorSpace sourceColorSpace, vsg::Options::ColorSpace destinationColorSpace);
 
         vsg::ref_ptr<vsg::Node> visit(const aiScene* in_scene, vsg::ref_ptr<const vsg::Options> in_options, const vsg::Path& ext);
         vsg::ref_ptr<vsg::Node> visit(const aiNode* node, int depth);


### PR DESCRIPTION
Uses the new `vsg::Options` features from https://github.com/vsg-dev/VulkanSceneGraph/commit/4474fb4d6ce8df9aa2634e231dd7fa4a24f77802 to make this controllable when loading data with atypical/off-spec colour data, or intentionally not using linear colour data internally.

