### PR TITLE
R16G16B16A16_Float and R32G32B32A32_Float formats for DDS textures

### DIFF
--- a/src/dds/dds.cpp
+++ b/src/dds/dds.cpp
@@ -55,7 +55,9 @@ namespace
         {tinyddsloader::DDSFile::DXGIFormat::BC2_UNorm, VK_FORMAT_BC2_UNORM_BLOCK},
         {tinyddsloader::DDSFile::DXGIFormat::BC2_UNorm_SRGB, VK_FORMAT_BC2_SRGB_BLOCK},
         {tinyddsloader::DDSFile::DXGIFormat::BC1_UNorm, VK_FORMAT_BC1_RGBA_UNORM_BLOCK},
-        {tinyddsloader::DDSFile::DXGIFormat::BC1_UNorm_SRGB, VK_FORMAT_BC1_RGBA_SRGB_BLOCK}};
+        {tinyddsloader::DDSFile::DXGIFormat::BC1_UNorm_SRGB, VK_FORMAT_BC1_RGBA_SRGB_BLOCK},
+        {tinyddsloader::DDSFile::DXGIFormat::R16G16B16A16_Float, VK_FORMAT_R16G16B16A16_SFLOAT},
+        {tinyddsloader::DDSFile::DXGIFormat::R32G32B32A32_Float, VK_FORMAT_R32G32B32A32_SFLOAT}};
 
     uint8_t* allocateAndCopyToContiguousBlock(tinyddsloader::DDSFile& ddsFile)
     {
@@ -203,11 +205,33 @@ namespace
                 case tinyddsloader::DDSFile::TextureDimension::Texture2D:
                     if (numArrays > 1)
                     {
+                        switch (it->first)
+                        {
+                            case tinyddsloader::DDSFile::DXGIFormat::R32G32B32A32_Float:
+                                vsg_data = vsg::vec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::vec4*>(raw), layout);
+                                break;
+                            case tinyddsloader::DDSFile::DXGIFormat::R16G16B16A16_Float:
+                                vsg_data = vsg::usvec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::usvec4*>(raw), layout);
+                                break;
+                            default:
                         vsg_data = vsg::ubvec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                                break;
+                        }
                     }
                     else
                     {
+                        switch (it->first)
+                        {
+                            case tinyddsloader::DDSFile::DXGIFormat::R32G32B32A32_Float:
+                                vsg_data = vsg::vec4Array2D::create(width, height, reinterpret_cast<vsg::vec4*>(raw), layout);
+                                break;
+                            case tinyddsloader::DDSFile::DXGIFormat::R16G16B16A16_Float:
+                                vsg_data = vsg::usvec4Array2D::create(width, height, reinterpret_cast<vsg::usvec4*>(raw), layout);
+                                break;
+                            default:
                         vsg_data = vsg::ubvec4Array2D::create(width, height, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                               break;
+                        }
                     }
                     break;
                 case tinyddsloader::DDSFile::TextureDimension::Texture3D:

--- a/src/dds/dds.cpp
+++ b/src/dds/dds.cpp
@@ -200,42 +200,64 @@ namespace
                 switch (dim)
                 {
                 case tinyddsloader::DDSFile::TextureDimension::Texture1D:
-                    vsg_data = vsg::ubvec4Array::create(width, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                    switch (layout.format)
+                    {
+                        case VK_FORMAT_R32G32B32A32_SFLOAT:
+                            vsg_data = vsg::vec4Array::create(width, reinterpret_cast<vsg::vec4*>(raw), layout);
+                            break;
+                        case VK_FORMAT_R16G16B16A16_SFLOAT:
+                            vsg_data = vsg::usvec4Array::create(width, reinterpret_cast<vsg::usvec4*>(raw), layout);
+                            break;
+                        default:
+                            vsg_data = vsg::ubvec4Array::create(width, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                            break;
+                    }
                     break;
                 case tinyddsloader::DDSFile::TextureDimension::Texture2D:
                     if (numArrays > 1)
                     {
-                        switch (it->first)
+                        switch (layout.format)
                         {
-                            case tinyddsloader::DDSFile::DXGIFormat::R32G32B32A32_Float:
+                            case VK_FORMAT_R32G32B32A32_SFLOAT:
                                 vsg_data = vsg::vec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::vec4*>(raw), layout);
                                 break;
-                            case tinyddsloader::DDSFile::DXGIFormat::R16G16B16A16_Float:
+                            case VK_FORMAT_R16G16B16A16_SFLOAT:
                                 vsg_data = vsg::usvec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::usvec4*>(raw), layout);
                                 break;
                             default:
-                        vsg_data = vsg::ubvec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                                vsg_data = vsg::ubvec4Array3D::create(width, height, numArrays, reinterpret_cast<vsg::ubvec4*>(raw), layout);
                                 break;
                         }
                     }
                     else
                     {
-                        switch (it->first)
+                        switch (layout.format)
                         {
-                            case tinyddsloader::DDSFile::DXGIFormat::R32G32B32A32_Float:
+                            case VK_FORMAT_R32G32B32A32_SFLOAT:
                                 vsg_data = vsg::vec4Array2D::create(width, height, reinterpret_cast<vsg::vec4*>(raw), layout);
                                 break;
-                            case tinyddsloader::DDSFile::DXGIFormat::R16G16B16A16_Float:
+                            case VK_FORMAT_R16G16B16A16_SFLOAT:
                                 vsg_data = vsg::usvec4Array2D::create(width, height, reinterpret_cast<vsg::usvec4*>(raw), layout);
                                 break;
                             default:
-                        vsg_data = vsg::ubvec4Array2D::create(width, height, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                                vsg_data = vsg::ubvec4Array2D::create(width, height, reinterpret_cast<vsg::ubvec4*>(raw), layout);
                                break;
                         }
                     }
                     break;
                 case tinyddsloader::DDSFile::TextureDimension::Texture3D:
-                    vsg_data = vsg::ubvec4Array3D::create(width, height, depth, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                    switch (layout.format)
+                    {
+                        case VK_FORMAT_R32G32B32A32_SFLOAT:
+                            vsg_data = vsg::vec4Array3D::create(width, height, depth, reinterpret_cast<vsg::vec4*>(raw), layout);
+                            break;
+                        case VK_FORMAT_R16G16B16A16_SFLOAT:
+                            vsg_data = vsg::usvec4Array3D::create(width, height, depth, reinterpret_cast<vsg::usvec4*>(raw), layout);
+                            break;
+                        default:
+                            vsg_data = vsg::ubvec4Array3D::create(width, height, depth, reinterpret_cast<vsg::ubvec4*>(raw), layout);
+                            break;
+                    }
                     break;
                 case tinyddsloader::DDSFile::TextureDimension::Unknown:
                     std::cerr << "dds::readDds() Num of dimension (" << (uint32_t)dim << ")  not supported." << std::endl;


### PR DESCRIPTION
Support for R16G16B16A16_Float and R32G32B32A32_Float formats in 2D DDS textures

This pull request is dependent on this other one
https://github.com/vsg-dev/VulkanSceneGraph/pull/1330