### PR TITLE
Apply shininess strength to correct parameter

### DIFF
--- a/src/assimp/SceneConverter.cpp
+++ b/src/assimp/SceneConverter.cpp
@@ -609,13 +609,13 @@ void SceneConverter::convert(const aiMaterial* material, vsg::DescriptorConfigur
 
         unsigned int maxValue = 1;
         float strength = 1.0f;
-        if (aiGetMaterialFloatArray(material, AI_MATKEY_SHININESS, &mat.shininess, &maxValue) == AI_SUCCESS)
-        {
-            maxValue = 1;
-            if (aiGetMaterialFloatArray(material, AI_MATKEY_SHININESS_STRENGTH, &strength, &maxValue) == AI_SUCCESS)
-                mat.shininess *= strength;
-        }
-        else
+        // any factors for other material parameters get multiplied in by AssImp before we see them, but the specular factor is different
+        // doing it like this means it's happening after conversion to the target colour space, which is sensible, but not necessarily what old data expects
+        if (aiGetMaterialFloatArray(material, AI_MATKEY_SHININESS_STRENGTH, &strength, &maxValue) == AI_SUCCESS)
+            mat.specular *= strength;
+
+        maxValue = 1;
+        if (aiGetMaterialFloatArray(material, AI_MATKEY_SHININESS, &mat.shininess, &maxValue) != AI_SUCCESS)
         {
             mat.shininess = 0.0f;
             mat.specular.set(0.0f, 0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
`AI_MATKEY_SHININESS_STRENGTH` is meant to be a multiplier for the specular colour, not the shininess. When it's 0.5, specularity should be half as bright, not half as shiny.

I discovered this problem when I realised an FBX file with a 0.25 `SpecularFactor` field had the unmodified (except for sRGB-to-linear conversion) `SpecularColor` value in its material uniform buffer. AssImp automatically applies other factors to their colours for FBX files (e.g. multiplying `DiffuseColor` by `DiffuseFactor` before exposing it to us as `AI_MATKEY_COLOR_DIFFUSE`), but uses `AI_MATKEY_SHININESS_STRENGTH` for `SpecularFactor` and exposes `SpecularColor` directly as `AI_MATKEY_COLOR_SPECULAR`.

I've verified that AssImp is consistently using `AI_MATKEY_SHININESS_STRENGTH` to attenuate the specular colour rather than the shininess, so it's just a misleading name rather than its FBX loader being inconsistent with the others.

There's a problem that leaves me not fully satisfied with this solution, though. For other color/factor combinations, as AssImp is multiplying them in for us, the multiplication's happening in sRGB space, and we're converting to linear RGB afterwards. The current `getColor` implementation does the conversion all in one, so we can't slip an extra multiplication in the middle without modifying it.

In a sane world, this would be a good thing, as it doesn't make sense to multiply an sRGB colour by a constant, but as it seems most FBX tools are pre-gamma-correctness or attempting to be compatible with older tools, we're probably doing something inconsistent with most assets we're likely to encounter.