### PR TITLE
Fix build

### DIFF
--- a/include/vsgXchange/3DTiles.h
+++ b/include/vsgXchange/3DTiles.h
@@ -23,6 +23,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 </editor-fold> */
 
+#include <vsg/threading/OperationThreads.h>
+
 #include <vsgXchange/gltf.h>
 
 namespace vsgXchange
@@ -210,7 +212,7 @@ namespace vsgXchange
             void report(vsg::LogOutput& output);
         };
 
-        class BatchTable;
+        struct BatchTable;
 
         struct VSGXCHANGE_DECLSPEC Batch : public vsg::Inherit<vsg::JSONtoMetaDataSchema, Batch>
         {

--- a/src/all/all.cpp
+++ b/src/all/all.cpp
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsgXchange/models.h>
 #include <vsgXchange/gltf.h>
 #include <vsgXchange/bin.h>
-#include <vsgXchange/3d-tiles.h>
+#include <vsgXchange/3DTiles.h>
 
 #include <vsg/io/Logger.h>
 #include <vsg/io/VSG.h>

--- a/src/gltf/SceneGraphBuilder.cpp
+++ b/src/gltf/SceneGraphBuilder.cpp
@@ -652,7 +652,7 @@ vsg::ref_ptr<vsg::Node> gltf::SceneGraphBuilder::createMesh(vsg::ref_ptr<gltf::M
                 auto itr = ushort_indices->begin();
                 for(auto value : *ubyte_indices)
                 {
-                    *(itr++) = static_cast<ushort>(value);
+                    *(itr++) = static_cast<uint16_t>(value);
                 }
 
                 vid->assignIndices(ushort_indices);


### PR DESCRIPTION
`3d-tiles.h` isn't a file, but `3DTiles.h` is.

`ushort` isn't a type (at least with the headers I've got), but `uint16_t` is.

`SceneGraphBuilder` depends on the definition of `OperationThreads` being available. I fixed this by including the relevant header in the `.h`, but it might be preferable to move the definitions of implicit functions into the `.cpp`.

`BatchTable` is a `struct`, so the forward declaration generates a warning if it says it's a `class`.