### PR TITLE
Optimised SDF generation

### DIFF
--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -892,8 +892,7 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
                         t /= denom;
 
                         stripContour.points.clear();
-                        // shift this a little to avoid numerical stability issues
-                        stripContour.points.push_back(point - (prevNormal + nextNormal) * 0.015625f);
+                        stripContour.points.push_back(point);
                         stripContour.points.push_back(prev2);
                         stripContour.points.push_back(prev2 + prevDir * t);
                         stripContour.points.push_back(next2);

--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -489,6 +489,7 @@ void freetype::Implementation::scanConvertLine(const Contours& local_contours, c
     scratchBuffer.push_back(std::numeric_limits<float>::infinity());
 
     auto itr = scratchBuffer.begin();
+    std::fill(row.begin(), row.end(), false);
     bool in = false;
     for (std::size_t i = 0; i < row.size(); ++i)
     {
@@ -498,7 +499,8 @@ void freetype::Implementation::scanConvertLine(const Contours& local_contours, c
             in = !in;
             ++itr;
         }
-        row[i] = in;
+        if (in)
+            row[i] = true;
     }
 }
 

--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -61,7 +61,6 @@ namespace vsgXchange
         struct Contour
         {
             std::vector<vsg::vec2> points;
-            std::vector<vsg::vec3> edges;
         };
 
         using Contours = std::list<Contour>;
@@ -775,16 +774,6 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
                 for (auto& v : points)
                 {
                     extents.add(v);
-                }
-
-                auto& edges = contour.edges;
-                edges.resize(points.size() - 1);
-                for (size_t i = 0; i < edges.size(); ++i)
-                {
-                    vsg::vec2 dv = points[i + 1] - points[i];
-                    float len = vsg::length(dv);
-                    dv /= len;
-                    edges[i].set(dv.x, dv.y, len);
                 }
             }
 

--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -945,7 +945,7 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
                 scanlineBuffer.resize(width + 2 * delta);
                 for (int r = -delta; r < static_cast<int>(height + delta); ++r)
                 {
-                    if (extents.containsY(r))
+                    if (extents.containsY(static_cast<float>(r)))
                     {
                         std::size_t index = atlas->index(xpos - delta, ypos + r);
                         vsg::vec2 rowStart{float(-delta), float(r)};


### PR DESCRIPTION
The implementation is based on *A Fast Algorithm for Computing the Closest Point and Distance Transform* by Sean Mauch. That paper's available here https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c4b3fe3775c2d718b1face6a1f65e7707ee99e03, although I don't know how likely that link is to still be alive when future generations look at this PR.

The gist of the algorithm is that instead of computing the distance for every texel from every line segment and choosing the minimum, it considers only the region around each line segment and vertex that could be closer to that element than its neighbours are, and does everything in an order that makes the bounds checking amenable to polygon scanline conversion (as it's about as fast to rasterise a whole line as it is to check whether a single point is within a polygon).

When running with a profiler taking four thousand samples per second, the original implementation took 6800-8000 samples for Arial, so 1.7-2 seconds, whereas this implementation takes 2300-2500 samples, so around 0.6 seconds, which is less than a third as long. That should be a significant enough improvement that a lot of apps will be able to tolerate loading fonts from scratch on launch which would have needed to preconvert fonts to `.vsgb` otherwise.

I've mostly tested Arial, and the SDF that's output is nearly identical. A small number of texels have a value that's different by one, which is explainable as rounding error given that the maths is done as 32-bit floats and then the results are converted to SNORM16. It shouldn't result in a visible difference when the SDF is sampled. (Note that text has some pretty bad artefacts under some conditions with or without this PR, which has been reported as https://github.com/vsg-dev/VulkanSceneGraph/issues/1311. From my testing, it appears to be because atlas tiles aren't big enough for the SDF values to get to zero before the edges are cropped, and if we fixed it by making the tiles bigger, this PR would become even more useful as each SDF texel is cheaper to generate).