### PR TITLE
Incorrect Glyph Loop Handling 

### DIFF
--- a/src/freetype/freetype.cpp
+++ b/src/freetype/freetype.cpp
@@ -597,8 +597,6 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
         charcode = FT_Get_First_Char(face, &glyph_index);
         while (glyph_index != 0)
         {
-            charcode = FT_Get_Next_Char(face, charcode, &glyph_index);
-
             error = FT_Load_Glyph(face, glyph_index, load_flags);
             if (error) continue;
 
@@ -613,31 +611,31 @@ vsg::ref_ptr<vsg::Object> freetype::Implementation::read(const vsg::Path& filena
             if (charcode == 32) hasSpace = true;
 
             sortedGlyphQuads.insert(quad);
+            
+            charcode = FT_Get_Next_Char(face, charcode, &glyph_index);
         }
     }
 
     if (!hasSpace)
     {
         FT_ULong charcode = 32;
-        FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
 
-        if (glyph_index != 0)
+        // Attempt to get the glyph for the space character, or use a fallback if not found
+        FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);        
+        
+        error = FT_Load_Glyph(face, glyph_index, load_flags);
+        if (!error)
         {
-            error = FT_Load_Glyph(face, glyph_index, load_flags);
+            GlyphQuad quad{
+                charcode,
+                glyph_index,
+                static_cast<unsigned int>(ceil(float(face->glyph->metrics.width) * freetype_pixel_size_scale)),
+                static_cast<unsigned int>(ceil(float(face->glyph->metrics.height) * freetype_pixel_size_scale))};
 
-            if (!error)
-            {
-                GlyphQuad quad{
-                    charcode,
-                    glyph_index,
-                    static_cast<unsigned int>(ceil(float(face->glyph->metrics.width) * freetype_pixel_size_scale)),
-                    static_cast<unsigned int>(ceil(float(face->glyph->metrics.height) * freetype_pixel_size_scale))};
+            sortedGlyphQuads.insert(quad);
 
-                sortedGlyphQuads.insert(quad);
-
-                hasSpace = true;
-            }
-        }
+            hasSpace = true;
+        }        
     }
 
     double total_width = 0.0;


### PR DESCRIPTION
- Incorrect Glyph Loop Handling - There is a loop in the code that systematically skips the first glyph of the font.

- When a space character is not defined in the font, we should use the fallback glyph. Currently, the system ignores the space character and creates a carriage return.