### PR TITLE
Fixed a problem with non transparent use of freetype.

### DIFF
--- a/src/freetype/build_vars.cmake
+++ b/src/freetype/build_vars.cmake
@@ -9,8 +9,12 @@ if(${vsgXchange_freetype})
     set(SOURCES ${SOURCES}
         freetype/freetype.cpp
     )
-    set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${FREETYPE_INCLUDE_DIRS})
-    set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${FREETYPE_LIBRARIES})
+    if(TARGET Freetype::Freetype)
+        set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} Freetype::Freetype)
+    else()
+        set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${FREETYPE_INCLUDE_DIRS})
+        set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${FREETYPE_LIBRARIES})
+    endif() 
     set(EXTRA_DEFINES ${EXTRA_DEFINES} USE_FREETYPE)
 
     if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
The freetype library was not automatically copied by cmake into a bin folder.

By using the cmake-internal nomenclature for identifying libraries (if available, hence the if/else), the process of “what do I need to copy where afterwards?” is also automatically set in motion during construction.